### PR TITLE
Issue #22: use the standard way of add non-standard policies

### DIFF
--- a/Kernel/TidyAll/OTOBO.pm
+++ b/Kernel/TidyAll/OTOBO.pm
@@ -2,7 +2,7 @@
 # OTOBO is a web-based ticketing system for service organisations.
 # --
 # Copyright (C) 2001-2020 OTRS AG, https://otrs.com/
-# Copyright (C) 2019-2020 Rother OSS GmbH, https://otobo.de/
+# Copyright (C) 2019-2021 Rother OSS GmbH, https://otobo.de/
 # --
 # This program is free software: you can redistribute it and/or modify it under
 # the terms of the GNU General Public License as published by the Free Software
@@ -18,8 +18,15 @@ package TidyAll::OTOBO;
 
 use strict;
 use warnings;
+use v5.24;
+use utf8;
 
-use Code::TidyAll 0.56;
+use File::Basename qw(dirname);
+use lib dirname(__FILE__) . '/Plugin/OTOBO';    # Find our Perl::Critic policies
+
+use parent qw(Code::TidyAll);
+
+# core modules
 use File::Basename;
 use File::Temp ();
 use IO::File;
@@ -27,9 +34,8 @@ use POSIX ":sys_wait_h";
 use Term::ANSIColor();
 use Time::HiRes qw(sleep);
 
-use parent qw(Code::TidyAll);
-
-# Require some needed modules here for clarity / better error messages.
+# CPAN modules, Require some needed modules here for clarity / better error messages.
+use Code::TidyAll 0.56;
 use Perl::Critic;
 use Perl::Tidy;
 
@@ -79,8 +85,7 @@ sub DetermineFrameworkVersionFromDirectory {
             my @Content    = $FileHandle->getlines();
             for my $Line (@Content) {
                 if ( $Line =~ m{ <Framework (?: [ ]+ [^<>]* )? > }xms ) {
-                    my ( $VersionMajor, $VersionMinor )
-                        = $Line =~ m{ <Framework (?: [ ]+ [^<>]* )? > (\d+) \. (\d+) \. [^<*]+ <\/Framework> }xms;
+                    my ( $VersionMajor, $VersionMinor ) = $Line =~ m{ <Framework (?: [ ]+ [^<>]* )? > (\d+) \. (\d+) \. [^<*]+ <\/Framework> }xms;
                     if (
                         $VersionMajor > $FrameworkVersionMajor
                         || (

--- a/Kernel/TidyAll/Plugin/OTOBO/Perl/PerlCritic.pm
+++ b/Kernel/TidyAll/Plugin/OTOBO/Perl/PerlCritic.pm
@@ -21,9 +21,6 @@ use warnings;
 use v5.24;
 use utf8;
 
-use File::Basename qw(dirname);
-use lib dirname(__FILE__) . '/../';    # Find our Perl::Critic policies
-
 use parent qw(TidyAll::Plugin::OTOBO::Perl);
 
 # core modules
@@ -32,14 +29,6 @@ use parent qw(TidyAll::Plugin::OTOBO::Perl);
 use Perl::Critic;
 
 # OTOBO modules
-use Perl::Critic::Policy::OTOBO::ProhibitGoto;
-use Perl::Critic::Policy::OTOBO::ProhibitLowPrecedenceOps;
-use Perl::Critic::Policy::OTOBO::ProhibitSmartMatchOperator;
-use Perl::Critic::Policy::OTOBO::ProhibitRandInTests;
-use Perl::Critic::Policy::OTOBO::ProhibitOpen;
-use Perl::Critic::Policy::OTOBO::RequireCamelCase;
-use Perl::Critic::Policy::OTOBO::RequireLabels;
-use Perl::Critic::Policy::OTOBO::RequireParensWithMethods;
 
 sub validate_file {
     my ( $Self, $Filename ) = @_;
@@ -66,15 +55,8 @@ sub validate_file {
             '-program-extensions' => [qw(.pl .t)],
         );
 
-        # explicitly add the OTOBO policies, run them regardless of severity
-        $Critic->add_policy( -policy => 'OTOBO::ProhibitGoto' );
-        $Critic->add_policy( -policy => 'OTOBO::ProhibitLowPrecedenceOps' );
-        $Critic->add_policy( -policy => 'OTOBO::ProhibitOpen' );
-        $Critic->add_policy( -policy => 'OTOBO::ProhibitRandInTests' );
-        $Critic->add_policy( -policy => 'OTOBO::ProhibitSmartMatchOperator' );
-        $Critic->add_policy( -policy => 'OTOBO::RequireCamelCase' );
-        $Critic->add_policy( -policy => 'OTOBO::RequireLabels' );
-        $Critic->add_policy( -policy => 'OTOBO::RequireParensWithMethods' );
+        # The OTOBO specific policies don't have to be added explicity,
+        # as they have the default severity $SEVERITY_HIGHEST = 5
 
         # explicitly add standard policy with defaul severity $SEVERITY_LOW, that is 2
         $Critic->add_policy( -policy => 'ControlStructures::ProhibitUnlessBlocks' );


### PR DESCRIPTION
The policies are found be Module::Pluggable when Perl::Critic is loaded.
Therefore make sure that @INC is set up when Perl::Critic is loaded.
No need to explicitly add the OTOBO policies, as they have the hightes severity.
The problem with 'no critic qw(OTODO::SomeThing)' disappears accordingly.